### PR TITLE
Fixed "Not a DICOM Stream" exception

### DIFF
--- a/src/main/java/com/bmdsoftware/pacs/dicoogle/ipfs/IPFSStore.java
+++ b/src/main/java/com/bmdsoftware/pacs/dicoogle/ipfs/IPFSStore.java
@@ -90,7 +90,7 @@ public class IPFSStore implements StorageInterface {
 
                         byte[] fileContents = new byte[0];
                         try {
-                            fileContents = ipfs.get(filePointer);
+                            fileContents = ipfs.cat(filePointer);
                         } catch (IOException e) {
                             logger.error("Failed to retrieve object", e);
                             return null;


### PR DESCRIPTION
ipfs.get(multihash) replaced by ipfs.cat(multihash)